### PR TITLE
[#10] Add compatibility with vite-plugin-legacy

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-plugin-css-injected-by-js",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-plugin-css-injected-by-js",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "A Vite plugin that takes the CSS and adds it to the page through the JS. For those who want a single JS file.",
   "main": "dist/plugin.js",
   "scripts": {

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -6,6 +6,8 @@ import { IndexHtmlTransformContext, IndexHtmlTransformResult, Plugin } from 'vit
  * @return {Plugin}
  */
 export default function cssInjectedByJsPlugin({topExecutionPriority} = { topExecutionPriority: true }): Plugin {
+    //Globally so we can add it to legacy and non-legacy bundle.
+    let cssToInject: string = '';
 
     return {
         apply: 'build',
@@ -32,6 +34,12 @@ export default function cssInjectedByJsPlugin({topExecutionPriority} = { topExec
 
             }
 
+            if (styleCode.length > 0) {
+
+                cssToInject = styleCode.trim();
+
+            }
+
             for (const key in bundle) {
 
                 if (bundle[key]) {
@@ -48,7 +56,7 @@ export default function cssInjectedByJsPlugin({topExecutionPriority} = { topExec
                             topCode = chunk.code;
                         }
 
-                        chunk.code = `${topCode}(function(){ try {var elementStyle = document.createElement('style'); elementStyle.innerText = \`${styleCode}\`; document.head.appendChild(elementStyle);} catch(e) {console.error(e, 'vite-plugin-css-injected-by-js: error when trying to add the style.');} })();${bottomCode}`;
+                        chunk.code = `${topCode}(function(){ try {var elementStyle = document.createElement('style'); elementStyle.innerText = \`${cssToInject}\`; document.head.appendChild(elementStyle);} catch(e) {console.error(e, 'vite-plugin-css-injected-by-js: error when trying to add the style.');} })();${bottomCode}`;
 
                         break;
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,16 +3,12 @@
   "compilerOptions": {
     "declaration": true,
     "esModuleInterop": true,
-    "lib": [
-      "es2018",
-      "dom"
-    ],
-    "module": "commonjs",
+    "module": "esnext",
     "moduleResolution": "node",
     "noUnusedLocals": true,
     "outDir": "dist",
     "strict": true,
-    "sourceMap": true,
-    "target": "es2018"
+    "sourceMap": false,
+    "target": "esnext"
   }
 }


### PR DESCRIPTION
The purpose is to add some code to add style to the generated legacy bundle as well as to the standard bundle. This way the end-user will still have the piece of code that adds the CSS to the page.