### PR TITLE
Support .mjs and .cjs file extension

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -46,7 +46,7 @@ function cssInjectedByJsPlugin(
 
                     if (
                         chunk.type === 'chunk' &&
-                        chunk.fileName.includes('.js') &&
+                        chunk.fileName.match(/.[cm]?js$/) != null &&
                         !chunk.fileName.includes('polyfill')
                     ) {
                         let topCode: string = '';


### PR DESCRIPTION
I am publishing my ESM bundle with a `.mjs` file extension. My understanding of vitejs/vite#6827 is that this will become the default in Library Mode to ensure compatibility with Node.js.

Currently, `vite-plugin-css-injected-by-js` only injects CSS into files whose file name contains `.js`. This pull request changes the behaviour to inject CSS into files whose file name ends with `.js`, `.cjs` or `.mjs`.

If you have time, it would be nice if you could publish a new release including this change, as I am currently blocked by this in migrating my project to Vite. Thank you for this useful plugin!