### PR TITLE
[#38] Fix styleId to use template literals

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -49,7 +49,7 @@ function injectionCSSCodePlugin(cssToInject: string, styleId: string | null): Pl
                 const cssCode = JSON.stringify(cssToInject.trim());
 
                 return `try{var elementStyle = document.createElement('style');${
-                    typeof styleId == 'string' && styleId.length > 0 ? 'elementStyle.id = "${styleId}";' : ''
+                    typeof styleId == 'string' && styleId.length > 0 ? 'elementStyle.id = `${styleId}`;' : ''
                 }elementStyle.appendChild(document.createTextNode(${cssCode}));document.head.appendChild(elementStyle);}catch(e){console.error('vite-plugin-css-injected-by-js', e);}`;
             }
         },

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -49,7 +49,7 @@ function injectionCSSCodePlugin(cssToInject: string, styleId: string | null): Pl
                 const cssCode = JSON.stringify(cssToInject.trim());
 
                 return `try{var elementStyle = document.createElement('style');${
-                    typeof styleId == 'string' && styleId.length > 0 ? 'elementStyle.id = `${styleId}`;' : ''
+                    typeof styleId == 'string' && styleId.length > 0 ? `elementStyle.id = ${styleId};` : ''
                 }elementStyle.appendChild(document.createTextNode(${cssCode}));document.head.appendChild(elementStyle);}catch(e){console.error('vite-plugin-css-injected-by-js', e);}`;
             }
         },


### PR DESCRIPTION
styleId was previously built as "${styleId}" - rendering on the page as <style id='${styleId}"/>. I've replaced the double quotes with template literals so the actual id is passed through

closes #38 