### PR TITLE
Adds support for custom injectCode

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,12 @@
 import { Plugin, ResolvedConfig } from 'vite';
 import { OutputAsset, OutputChunk } from 'rollup';
-import { buildCSSInjectionCode, removeLinkStyleSheets } from './utils.js';
+import { buildCSSInjectionCode, InjectCode, removeLinkStyleSheets } from './utils.js';
+
+type Options = {
+    topExecutionPriority?: boolean;
+    styleId?: string;
+    injectCode?: InjectCode;
+};
 
 /**
  * Inject the CSS compiled with JS.
@@ -8,7 +14,7 @@ import { buildCSSInjectionCode, removeLinkStyleSheets } from './utils.js';
  * @return {Plugin}
  */
 export default function cssInjectedByJsPlugin(
-    { topExecutionPriority, styleId }: { topExecutionPriority?: boolean; styleId?: string } | undefined = {
+    { topExecutionPriority, styleId, injectCode }: Options | undefined = {
         topExecutionPriority: true,
         styleId: '',
     }
@@ -64,7 +70,7 @@ export default function cssInjectedByJsPlugin(
 
             const jsAsset = bundle[jsAssets[0]] as OutputChunk;
 
-            const cssInjectionCode = await buildCSSInjectionCode(cssToInject, styleId);
+            const cssInjectionCode = await buildCSSInjectionCode(injectCode, cssToInject, styleId);
             const appCode = jsAsset.code;
             jsAsset.code = topExecutionPriority ? '' : appCode;
             jsAsset.code += cssInjectionCode ? cssInjectionCode.code : '';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import { Plugin, ResolvedConfig } from 'vite';
 import { OutputAsset, OutputChunk } from 'rollup';
-import { buildCSSInjectionCode, InjectCode, removeLinkStyleSheets } from './utils.js';
+import { buildCSSInjectionCode, removeLinkStyleSheets, InjectCode } from './utils.js';
 
 type Options = {
     topExecutionPriority?: boolean;
@@ -70,7 +70,7 @@ export default function cssInjectedByJsPlugin(
 
             const jsAsset = bundle[jsAssets[0]] as OutputChunk;
 
-            const cssInjectionCode = await buildCSSInjectionCode(injectCode, cssToInject, styleId);
+            const cssInjectionCode = await buildCSSInjectionCode(cssToInject, styleId, injectCode);
             const appCode = jsAsset.code;
             jsAsset.code = topExecutionPriority ? '' : appCode;
             jsAsset.code += cssInjectionCode ? cssInjectionCode.code : '';

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -11,15 +11,15 @@ const defaultInjectCode: InjectCode = (cssCode, styleId) =>
     }elementStyle.appendChild(document.createTextNode(${cssCode}));document.head.appendChild(elementStyle);}}catch(e){console.error('vite-plugin-css-injected-by-js', e);}`;
 
 export async function buildCSSInjectionCode(
-    injectCode: InjectCode = defaultInjectCode,
     cssToInject: string,
-    styleId?: string
+    styleId?: string,
+    injectCode?: InjectCode
 ): Promise<OutputChunk | null> {
     const res = await build({
         root: '',
         configFile: false,
         logLevel: 'error',
-        plugins: [injectionCSSCodePlugin(injectCode, cssToInject, styleId)],
+        plugins: [injectionCSSCodePlugin(cssToInject, styleId, injectCode)],
         build: {
             write: false,
             target: 'es2015',
@@ -43,12 +43,12 @@ export async function buildCSSInjectionCode(
 }
 
 /**
- * @param {InjectCode} injectCode
  * @param {string} cssToInject
  * @param {string|null} styleId
+ * @param {InjectCode|null} injectCode
  * @return {Plugin}
  */
-function injectionCSSCodePlugin(injectCode: InjectCode, cssToInject: string, styleId?: string): Plugin {
+function injectionCSSCodePlugin(cssToInject: string, styleId?: string, injectCode?: InjectCode): Plugin {
     return {
         name: 'vite:injection-css-code-plugin',
         resolveId(id: string) {
@@ -59,8 +59,8 @@ function injectionCSSCodePlugin(injectCode: InjectCode, cssToInject: string, sty
         load(id: string) {
             if (id == cssInjectedByJsId) {
                 const cssCode = JSON.stringify(cssToInject.trim());
-
-                return injectCode(cssCode, styleId);
+                const injectFunction = injectCode || defaultInjectCode;
+                return injectFunction(cssCode, styleId);
             }
         },
     };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,14 +1,25 @@
 import { build, Plugin } from 'vite';
 import { OutputChunk } from 'rollup';
 
+export type InjectCode = (cssCode: string, styleId?: string) => string;
+
 const cssInjectedByJsId = '\0vite/all-css';
 
-export async function buildCSSInjectionCode(cssToInject: string, styleId?: string): Promise<OutputChunk | null> {
+const defaultInjectCode: InjectCode = (cssCode, styleId) =>
+    `try{if(typeof document != 'undefined'){var elementStyle = document.createElement('style');${
+        typeof styleId == 'string' && styleId.length > 0 ? `elementStyle.id = '${styleId}';` : ''
+    }elementStyle.appendChild(document.createTextNode(${cssCode}));document.head.appendChild(elementStyle);}}catch(e){console.error('vite-plugin-css-injected-by-js', e);}`;
+
+export async function buildCSSInjectionCode(
+    injectCode: InjectCode = defaultInjectCode,
+    cssToInject: string,
+    styleId?: string
+): Promise<OutputChunk | null> {
     const res = await build({
         root: '',
         configFile: false,
         logLevel: 'error',
-        plugins: [injectionCSSCodePlugin(cssToInject, styleId)],
+        plugins: [injectionCSSCodePlugin(injectCode, cssToInject, styleId)],
         build: {
             write: false,
             target: 'es2015',
@@ -32,11 +43,12 @@ export async function buildCSSInjectionCode(cssToInject: string, styleId?: strin
 }
 
 /**
+ * @param {InjectCode} injectCode
  * @param {string} cssToInject
  * @param {string|null} styleId
  * @return {Plugin}
  */
-function injectionCSSCodePlugin(cssToInject: string, styleId?: string): Plugin {
+function injectionCSSCodePlugin(injectCode: InjectCode, cssToInject: string, styleId?: string): Plugin {
     return {
         name: 'vite:injection-css-code-plugin',
         resolveId(id: string) {
@@ -48,9 +60,7 @@ function injectionCSSCodePlugin(cssToInject: string, styleId?: string): Plugin {
             if (id == cssInjectedByJsId) {
                 const cssCode = JSON.stringify(cssToInject.trim());
 
-                return `try{if(typeof document != 'undefined'){var elementStyle = document.createElement('style');${
-                    typeof styleId == 'string' && styleId.length > 0 ? `elementStyle.id = '${styleId}';` : ''
-                }elementStyle.appendChild(document.createTextNode(${cssCode}));document.head.appendChild(elementStyle);}}catch(e){console.error('vite-plugin-css-injected-by-js', e);}`;
+                return injectCode(cssCode, styleId);
             }
         },
     };


### PR DESCRIPTION
Hey there!

I wanted to open an issue to discuss this idea, but since I ended up implementing it to validate that my solution would be viable, I figured I'd open a PR.

**The problem I'm solving:** I want to use this plugin to inject CSS as JS on a component library I'm building. The component library has to support SSR though, without causing [FOUC](https://en.wikipedia.org/wiki/Flash_of_unstyled_content).

Inspired by `rollup-plugin-postcss`'s `inject` property ([which allows to customize the JS code that gets injected](https://github.com/egoist/rollup-plugin-postcss#inject)), I've added a new configuration option called `injectCode`, which is a function that gets `cssCode` and `styleId` and returns a string representing the JS code to be injected.

This way, I can customize my plugin configuration to work on both CSR and SSR, by doing something like:

```typescript
// vite.config.ts

export default defineConfig({
  plugins: [
    cssInjectedByJsPlugin({
      injectCode: (cssCode, styleId) =>
        `
          try {
            var cssCode=${cssCode};
            
            if(typeof document != 'undefined') {
              var elementStyle = document.createElement('style');
              ${
                typeof styleId == 'string' && styleId.length > 0
                  ? `elementStyle.id = '${styleId}';`
                  : ''
              }
              elementStyle.appendChild(document.createTextNode(cssCode));
              document.head.appendChild(elementStyle);
            } else if (global != 'undefined') {
              if (!global.ssrStyles) global.ssrStyles = [];
              global.ssrStyles.push(cssCode);
            }
          } catch (e) {
            console.error('vite-plugin-css-injected-by-js', e);
          }
        `,
    }),
  ],
});
```

This way, when rendering for SSR, I can access `global.ssrStyles` and inject those styles on the initial HTML, solving the FOUC issue.

I like this approach because it's a generic solution, allowing users of the plugin to extend its functionality.

---

Happy to hear your thoughts and feedback @Marco-Prontera 