### PR TITLE
Allow for Strict CSPs through `useStrictCSP` flag

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ type Options = {
     injectCodeFunction?: InjectCodeFunction;
     styleId?: string;
     topExecutionPriority?: boolean;
+    useStrictCSP?: boolean;
 };
 
 /**
@@ -15,7 +16,7 @@ type Options = {
  * @return {Plugin}
  */
 export default function cssInjectedByJsPlugin(
-    { topExecutionPriority, styleId, injectCode, injectCodeFunction }: Options | undefined = {
+    { topExecutionPriority, styleId, injectCode, injectCodeFunction, useStrictCSP }: Options | undefined = {
         topExecutionPriority: true,
         styleId: '',
     }
@@ -71,7 +72,13 @@ export default function cssInjectedByJsPlugin(
 
             const jsAsset = bundle[jsAssets[0]] as OutputChunk;
 
-            const cssInjectionCode = await buildCSSInjectionCode(cssToInject, styleId, injectCode, injectCodeFunction);
+            const cssInjectionCode = await buildCSSInjectionCode({
+                cssToInject,
+                styleId,
+                injectCode,
+                injectCodeFunction,
+                useStrictCSP,
+            });
             const appCode = jsAsset.code;
             jsAsset.code = topExecutionPriority ? '' : appCode;
             jsAsset.code += cssInjectionCode ? cssInjectionCode.code : '';

--- a/src/utils.spec.ts
+++ b/src/utils.spec.ts
@@ -1,12 +1,22 @@
-import { test, expect, vi } from 'vitest';
+import { test, expect, vi, beforeAll } from 'vitest';
 import { buildCSSInjectionCode } from './utils';
 
 const onerror = vi.fn();
 window.onerror = onerror;
 
+beforeAll(() => {
+    const $meta = document.createElement('meta');
+    $meta.setAttribute('property', 'csp-nonce');
+    $meta.setAttribute('content', 'abc-123');
+    document.head.prepend($meta);
+});
+
 test('Generate JS that applies styles', async () => {
     const styleId = `style-${Date.now()}`;
-    const output = await buildCSSInjectionCode('body { color: red; }', styleId);
+    const output = await buildCSSInjectionCode({
+        cssToInject: 'body { color: red; }',
+        styleId,
+    });
 
     const $script = document.createElement('script');
     $script.textContent = output?.code || 'throw new Error("UNCAUGHT ERROR")';
@@ -22,13 +32,42 @@ test('Generate JS that applies styles', async () => {
     expect(getComputedStyle(document.body).color).toBe('red');
 });
 
+test('Generate JS that applies styles, with a nonce', async () => {
+    const styleId = `style-${Date.now()}`;
+    const output = await buildCSSInjectionCode({
+        cssToInject: 'body { color: red; }',
+        styleId,
+        useStrictCSP: true,
+    });
+
+    const $script = document.createElement('script');
+    $script.textContent = output?.code || 'throw new Error("UNCAUGHT ERROR")';
+    document.head.appendChild($script);
+
+    // Doesn't error
+    expect(onerror).not.toBeCalled();
+
+    // StyleId applied
+    const $style = document.head.querySelector(`style#${styleId}`);
+    expect($style).not.toBeNull();
+
+    // Applied style!
+    expect(getComputedStyle(document.body).color).toBe('red');
+
+    expect($style?.nonce).toBe('abc-123');
+});
+
 test('Generate JS that applies styles from custom code', async () => {
     const styleId = `style-custom-${Date.now()}`;
-    const output = await buildCSSInjectionCode('body { color: red; }', styleId, undefined, (css, { styleId }) => {
-        const $style = document.createElement('style');
-        $style.setAttribute('custom-style', '');
-        $style.appendChild(document.createTextNode(css));
-        document.head.appendChild($style);
+    const output = await buildCSSInjectionCode({
+        cssToInject: 'body { color: red; }',
+        styleId,
+        injectCodeFunction: (css) => {
+            const $style = document.createElement('style');
+            $style.setAttribute('custom-style', '');
+            $style.appendChild(document.createTextNode(css));
+            document.head.appendChild($style);
+        },
     });
 
     const $script = document.createElement('script');
@@ -43,4 +82,38 @@ test('Generate JS that applies styles from custom code', async () => {
 
     // StyleId applied
     expect(document.head.querySelector(`style#${styleId}`)).toBeNull();
+});
+
+test('Generate JS that applies styles from custom code, with a nonce', async () => {
+    const styleId = `style-custom-${Date.now()}`;
+    const output = await buildCSSInjectionCode({
+        cssToInject: 'body { color: red; }',
+        styleId,
+        useStrictCSP: true,
+        injectCodeFunction: (css, { styleId }) => {
+            const $style = document.createElement('style');
+            $style.setAttribute('custom-style-strict', '');
+
+            const nonce = document.querySelector<HTMLMetaElement>('meta[property=csp-nonce]')?.content;
+            $style.nonce = nonce;
+
+            $style.appendChild(document.createTextNode(css));
+            document.head.appendChild($style);
+        },
+    });
+
+    const $script = document.createElement('script');
+    $script.textContent = output?.code || 'throw new Error("UNCAUGHT ERROR")';
+    document.head.appendChild($script);
+
+    // Doesn't error
+    expect(onerror).not.toBeCalled();
+
+    const elem = document.head.querySelector<HTMLStyleElement>(`style[custom-style-strict]`);
+
+    // Custom attribute added
+    expect(elem).not.toBeNull();
+
+    // Did we dynamically set the nonce?
+    expect(elem?.nonce).toBe('abc-123');
 });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,6 +3,7 @@ import { OutputChunk } from 'rollup';
 
 interface InjectCodeOptions {
     styleId?: string;
+    useStrictCSP?: boolean;
 }
 
 export type InjectCode = (cssCode: string, options: InjectCodeOptions) => string;
@@ -10,9 +11,11 @@ export type InjectCodeFunction = (cssCode: string, options: InjectCodeOptions) =
 
 const cssInjectedByJsId = '\0vite/all-css';
 
-const defaultInjectCode: InjectCode = (cssCode, { styleId }) =>
+const defaultInjectCode: InjectCode = (cssCode, { styleId, useStrictCSP }) =>
     `try{if(typeof document != 'undefined'){var elementStyle = document.createElement('style');${
         typeof styleId == 'string' && styleId.length > 0 ? `elementStyle.id = '${styleId}';` : ''
+    }${
+        useStrictCSP ? `elementStyle.nonce = document.head.querySelector('meta[property=csp-nonce]')?.content;` : ''
     }elementStyle.appendChild(document.createTextNode(${cssCode}));document.head.appendChild(elementStyle);}}catch(e){console.error('vite-plugin-css-injected-by-js', e);}`;
 
 interface BuildCSSInjectionCodeInput {
@@ -20,18 +23,20 @@ interface BuildCSSInjectionCodeInput {
     styleId?: string;
     injectCode?: InjectCode;
     injectCodeFunction?: InjectCodeFunction;
+    useStrictCSP?: boolean;
 }
 export async function buildCSSInjectionCode({
     cssToInject,
     styleId,
     injectCode,
     injectCodeFunction,
+    useStrictCSP,
 }: BuildCSSInjectionCodeInput): Promise<OutputChunk | null> {
     const res = await build({
         root: '',
         configFile: false,
         logLevel: 'error',
-        plugins: [injectionCSSCodePlugin({ cssToInject, styleId, injectCode, injectCodeFunction })],
+        plugins: [injectionCSSCodePlugin({ cssToInject, styleId, injectCode, injectCodeFunction, useStrictCSP })],
         build: {
             write: false,
             target: 'es2015',
@@ -59,6 +64,7 @@ interface InjectionCSSCodePluginInput {
     styleId?: string;
     injectCode?: InjectCode;
     injectCodeFunction?: InjectCodeFunction;
+    useStrictCSP?: boolean;
 }
 
 /**
@@ -72,6 +78,7 @@ function injectionCSSCodePlugin({
     injectCode,
     injectCodeFunction,
     styleId,
+    useStrictCSP,
 }: InjectionCSSCodePluginInput): Plugin {
     return {
         name: 'vite:injection-css-code-plugin',
@@ -84,10 +91,10 @@ function injectionCSSCodePlugin({
             if (id == cssInjectedByJsId) {
                 const cssCode = JSON.stringify(cssToInject.trim());
                 if (injectCodeFunction) {
-                    return `(${injectCodeFunction})(${cssCode}, ${JSON.stringify({ styleId })})`;
+                    return `(${injectCodeFunction})(${cssCode}, ${JSON.stringify({ styleId, useStrictCSP })})`;
                 }
                 const injectFunction = injectCode || defaultInjectCode;
-                return injectFunction(cssCode, { styleId });
+                return injectFunction(cssCode, { styleId, useStrictCSP });
             }
         },
     };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -15,17 +15,23 @@ const defaultInjectCode: InjectCode = (cssCode, { styleId }) =>
         typeof styleId == 'string' && styleId.length > 0 ? `elementStyle.id = '${styleId}';` : ''
     }elementStyle.appendChild(document.createTextNode(${cssCode}));document.head.appendChild(elementStyle);}}catch(e){console.error('vite-plugin-css-injected-by-js', e);}`;
 
-export async function buildCSSInjectionCode(
-    cssToInject: string,
-    styleId?: string,
-    injectCode?: InjectCode,
-    injectCodeFunction?: InjectCodeFunction
-): Promise<OutputChunk | null> {
+interface BuildCSSInjectionCodeInput {
+    cssToInject: string;
+    styleId?: string;
+    injectCode?: InjectCode;
+    injectCodeFunction?: InjectCodeFunction;
+}
+export async function buildCSSInjectionCode({
+    cssToInject,
+    styleId,
+    injectCode,
+    injectCodeFunction,
+}: BuildCSSInjectionCodeInput): Promise<OutputChunk | null> {
     const res = await build({
         root: '',
         configFile: false,
         logLevel: 'error',
-        plugins: [injectionCSSCodePlugin(cssToInject, styleId, injectCode, injectCodeFunction)],
+        plugins: [injectionCSSCodePlugin({ cssToInject, styleId, injectCode, injectCodeFunction })],
         build: {
             write: false,
             target: 'es2015',
@@ -48,18 +54,25 @@ export async function buildCSSInjectionCode(
     return _cssChunk.output[0];
 }
 
+interface InjectionCSSCodePluginInput {
+    cssToInject: string;
+    styleId?: string;
+    injectCode?: InjectCode;
+    injectCodeFunction?: InjectCodeFunction;
+}
+
 /**
  * @param {string} cssToInject
  * @param {string|null} styleId
  * @param {InjectCode|null} injectCode
  * @return {Plugin}
  */
-function injectionCSSCodePlugin(
-    cssToInject: string,
-    styleId?: string,
-    injectCode?: InjectCode,
-    injectCodeFunction?: InjectCodeFunction
-): Plugin {
+function injectionCSSCodePlugin({
+    cssToInject,
+    injectCode,
+    injectCodeFunction,
+    styleId,
+}: InjectionCSSCodePluginInput): Plugin {
     return {
         name: 'vite:injection-css-code-plugin',
         resolveId(id: string) {


### PR DESCRIPTION
It is possible for the CSS to be injected by the JS generated will be blocked from running with certain configurations of CSPs.

Working from prior-art, react-jss supports runtime nonce resolution based on a <meta> tag:

https://cssinjs.org/csp/?v=v10.9.2.
I have added a useStrictCSP configuration option that adds a nonce to style tags based on:
 `<meta property="csp-nonce" content={{ nonce }} />`