### PR TITLE
[#100] Wrong globalCssToInject - remove old plugin-legacy support since isn't required anymore

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -224,8 +224,6 @@ export async function relativeCssInjection(
     }
 }
 
-// Globally so we can add it to legacy and non-legacy bundle.
-let globalCssToInject = '';
 export async function globalCssInjection(
     bundle: OutputBundle,
     cssAssets: string[],
@@ -243,10 +241,7 @@ export async function globalCssInjection(
     process.env.VITE_CSS_INJECTED_BY_JS_DEBUG &&
         debugLog(`[vite-plugin-css-injected-by-js] Global CSS Assets: [${cssAssets.join(',')}]`);
     const allCssCode = concatCssAndDeleteFromBundle(bundle, cssAssets);
-    if (allCssCode.length > 0) {
-        globalCssToInject = allCssCode;
-    }
-    const globalCssInjectionCode = globalCssToInject.length > 0 ? (await buildCssCode(globalCssToInject))?.code : '';
+    const cssInjectionCode = allCssCode.length > 0 ? (await buildCssCode(allCssCode))?.code : '';
 
     for (const jsTargetKey of jsTargetBundleKeys) {
         const jsAsset = bundle[jsTargetKey] as OutputChunk;
@@ -254,7 +249,7 @@ export async function globalCssInjection(
             debugLog(`[vite-plugin-css-injected-by-js] Global CSS inject: ${jsAsset.fileName}`);
         jsAsset.code = buildOutputChunkWithCssInjectionCode(
             jsAsset.code,
-            globalCssInjectionCode ?? '',
+            cssInjectionCode ?? '',
             topExecutionPriorityFlag
         );
     }


### PR DESCRIPTION
The goal of this PR is to fix the bug described here #100.
The code causing this bug is related to the old code to support injection of the CSS also in the legacy chunk generated in the [plugin-legacy](https://github.com/vitejs/vite/tree/main/packages/plugin-legacy) officially provided by the ViteJS project.

I'll follow up on this issue https://github.com/vitejs/vite/issues/2062 to find out if there are any new updates to the plugin-legacy code behavior.