### PR TITLE
fix: correctly remove multiple /* empty css */ occurrences

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -301,7 +301,7 @@ export function buildOutputChunkWithCssInjectionCode(
     cssInjectionCode: string,
     topExecutionPriorityFlag: boolean
 ): string {
-    const appCode = jsAssetCode.replace(/\/\*.*empty css.*\*\//, '');
+    const appCode = jsAssetCode.replaceAll(/\/\*\s*empty css\s*\*\//g, '');
     jsAssetCode = topExecutionPriorityFlag ? '' : appCode;
     jsAssetCode += cssInjectionCode;
     jsAssetCode += !topExecutionPriorityFlag ? '' : appCode;

--- a/test/utils.spec.ts
+++ b/test/utils.spec.ts
@@ -523,6 +523,14 @@ describe('utils', () => {
 
                 expect(bundle['a.js'].code).toEqual('a');
             });
+
+            it('should remove occurrences of /* empty css */ from the bundled code', async () => {
+                bundle['a.js'] = generateJsChunk('a', ['a.css']);
+                bundle['a.js'].code = `/* empty css */${bundle['a.js'].code}/* empty css     */`;
+                await relativeCssInjection(bundle, buildJsCssMap(bundle), buildCssCodeMock, true);
+
+                expect(bundle['a.js'].code).toEqual('aa');
+            });
         });
 
         describe('globalCssInjection', () => {
@@ -544,6 +552,16 @@ describe('utils', () => {
             it('should inject all css', async () => {
                 const cssAssets = ['a.css', 'b.css', 'c.css'];
                 bundle['a.js'] = generateJsChunk('a', cssAssets, true);
+
+                await globalCssInjection(bundle, cssAssets, buildCssCodeMock, undefined, true);
+
+                expect(bundle['a.js'].code).toEqual('abca');
+            });
+
+            it('should remove occurrences of /* empty css */ from the bundled code', async () => {
+                const cssAssets = ['a.css', 'b.css', 'c.css'];
+                bundle['a.js'] = generateJsChunk('a', cssAssets, true);
+                bundle['a.js'].code = `/* empty css */${bundle['a.js'].code}/* empty css     */`;
 
                 await globalCssInjection(bundle, cssAssets, buildCssCodeMock, undefined, true);
 


### PR DESCRIPTION
Fixes https://github.com/marco-prontera/vite-plugin-css-injected-by-js/issues/129