### PR TITLE
[#133] change replaceAll to replace for NodeJS 14 compatibility

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -301,7 +301,7 @@ export function buildOutputChunkWithCssInjectionCode(
     cssInjectionCode: string,
     topExecutionPriorityFlag: boolean
 ): string {
-    const appCode = jsAssetCode.replaceAll(/\/\*\s*empty css\s*\*\//g, '');
+    const appCode = jsAssetCode.replace(/\/\*\s*empty css\s*\*\//g, '');
     jsAssetCode = topExecutionPriorityFlag ? '' : appCode;
     jsAssetCode += cssInjectionCode;
     jsAssetCode += !topExecutionPriorityFlag ? '' : appCode;


### PR DESCRIPTION
replaceAll is available from Nodejs 15+
But the regex here works also with replace which also guarantees nodejs 14 compatibility