### PR TITLE
[#142] Fix cssAssetsFilterFunction breaks dynamic imports

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vite-plugin-css-injected-by-js",
-    "version": "3.5.0",
+    "version": "3.5.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "vite-plugin-css-injected-by-js",
-            "version": "3.5.0",
+            "version": "3.5.1",
             "license": "MIT",
             "devDependencies": {
                 "@types/node": "^18.11.15",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "vite-plugin-css-injected-by-js",
-    "version": "3.5.0",
+    "version": "3.5.1",
     "description": "A Vite plugin that takes the CSS and adds it to the page through the JS. For those who want a single JS file.",
     "main": "dist/cjs/index.js",
     "module": "dist/esm/index.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -103,6 +103,14 @@ export default function cssInjectedByJsPlugin({
                             );
                     }
                 } else {
+                    const allCssAssets = Object.keys(bundle).filter(
+                        (i) =>
+                            bundle[i].type == 'asset' &&
+                            bundle[i].fileName.endsWith('.css')
+                    );
+
+                    unusedCssAssets = allCssAssets.filter(cssAsset => !cssAssets.includes(cssAsset));
+
                     await globalCssInjection(
                         bundle,
                         cssAssets,


### PR DESCRIPTION
The goal of this PR is to fix the global injection logic since it doesn't preserve the vite imports when the cssAssetsFilterFunction is configured.

closes #142 