### PR TITLE
fix: replace picocolors with plain console logs

### DIFF
--- a/src/utils.log.ts
+++ b/src/utils.log.ts
@@ -1,12 +1,7 @@
-// picocolors: Transitive dependency from Vite.
-import pc from 'picocolors';
-
 export function warnLog(msg: string): void {
-    // Use yellow for warnings
-    console.warn(pc.yellow(`\n${msg}`));
+    console.warn(`\n${msg}`);
 }
 
 export function debugLog(msg: string): void {
-    // Use blue for debug
-    console.debug(pc.blue(`\n${msg}`));
+    console.debug(`\n${msg}`);
 }


### PR DESCRIPTION
## Problem

`picocolors` is imported in `src/utils.log.ts` but is not available at runtime in strict pnpm monorepos (`hoist=false`). Vite 8 no longer includes `picocolors` as a dependency (removed in the migration to `rolldown`), so the assumption in the comment _"Transitive dependency from Vite"_ no longer holds.

This causes a build failure in pnpm monorepos with `hoist=false`:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'picocolors' imported from
.../vite-plugin-css-injected-by-js/dist/utils.log.js
```

Reproduction: https://github.com/smouillour/picocolors-issue

## Fix

Remove the `picocolors` dependency entirely and replace the colored output with plain `console.warn` / `console.debug` calls — no new dependencies introduced.