### PR TITLE
ci: update outdated GitHub Actions and improve CI reliability

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,13 +18,14 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
-      - run: npm install
+          cache: 'npm'
+      - run: npm ci
       - run: npm run coverage
       - run: npm run ci-test
       - run: npm run test:integration

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,14 +1,3 @@
-# For most projects, this workflow file will not need changing; you simply need
-# to commit it to your repository.
-#
-# You may wish to alter this file to override the set of languages analyzed,
-# or to provide custom queries or build logic.
-#
-# ******** NOTE ********
-# We have attempted to detect the languages in your repository. Please check
-# the `language` matrix defined below to confirm you have the correct set of
-# supported CodeQL languages.
-#
 name: "CodeQL"
 
 on:
@@ -30,39 +19,18 @@ jobs:
       fail-fast: false
       matrix:
         language: [ 'javascript' ]
-        # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python' ]
-        # Learn more:
-        # https://docs.github.com/en/free-pro-team@latest/github/finding-security-vulnerabilities-and-errors-in-your-code/configuring-code-scanning#changing-the-languages-that-are-analyzed
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
-      # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v1
+        uses: github/codeql-action/init@v3
         with:
           languages: ${{ matrix.language }}
-          # If you wish to specify custom queries, you can do so here or in a config file.
-          # By default, queries listed here will override any specified in a config file.
-          # Prefix the list here with "+" to use these queries and those in the config file.
-          # queries: ./path/to/local/query, your-org/your-repo/queries@main
 
-      # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
-      # If this step fails, then you should remove it and run the build manually (see below)
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v1
-
-      # ℹ️ Command-line programs to run using the OS shell.
-      # 📚 https://git.io/JvXDl
-
-      # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
-      #    and modify them (or add more) to build your code if your project
-      #    uses a compiled language
-
-      #- run: |
-      #   make bootstrap
-      #   make release
+        uses: github/codeql-action/autobuild@v3
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v1
+        uses: github/codeql-action/analyze@v3


### PR DESCRIPTION
## Summary

Updates all outdated GitHub Actions to their current major versions and improves CI reliability.

Fixes #165

## Changes

### ci.yml
- `actions/checkout` v3 → **v4**
- `actions/setup-node` v3 → **v4** with `cache: 'npm'` enabled
- `npm install` → **`npm ci`** (reproducible builds from lockfile)

### codeql-analysis.yml
- `actions/checkout` v2 → **v4**
- `github/codeql-action/init` v1 → **v3**
- `github/codeql-action/autobuild` v1 → **v3**
- `github/codeql-action/analyze` v1 → **v3**
- Removed outdated boilerplate comments

## Why

- **v3/v2/v1 actions are deprecated** and may stop working. GitHub has been urging users to upgrade.
- **`npm ci`** is the recommended command for CI — it installs exactly from the lockfile, ensuring reproducible builds. `npm install` can modify the lockfile.
- **npm caching** in setup-node significantly speeds up CI by reusing downloaded packages across runs.
- **CodeQL v1 actions** are particularly concerning as they use the legacy CodeQL runner which has been sunset.