### PR TITLE
ci: update actions and use npm ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,13 +18,14 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
-      - run: npm install
+          cache: 'npm'
+      - run: npm ci
       - run: npm run coverage
       - run: npm run ci-test
       - run: npm run test:integration


### PR DESCRIPTION
## Summary
- bump actions/checkout to v4
- bump actions/setup-node to v4 and enable npm cache
- switch npm install to npm ci for deterministic CI

## Testing
- not run (CI config change only)

Closes #165